### PR TITLE
Make the plugin usable again

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,22 @@
+
+[check-manifest]
+ignore =
+    .checkignore
+    .circleci
+    .circleci/*
+    .codecov.yml
+    .coveragerc
+    RELEASE.md
+    azure-pipelines.yml
+    conftest.py
+    continuous_integration
+    continuous_integration/*
+    crowdin.yml
+    doc
+    doc/*
+    requirements
+    requirements/*
+    runtests.py
+
+ignore-bad-ideas =
+    *.mo

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,79 @@
+# -*- coding: utf-8 -*-
+# -----------------------------------------------------------------------------
+# Copyright (c) Spyder Project Contributors
+#
+# Licensed under the terms of the MIT License
+# (see LICENSE.txt for details)
+# -----------------------------------------------------------------------------
+"""Setup script for spyder_vcs."""
+
+# Standard library imports
+import ast
+import os
+
+# Third party imports
+from setuptools import find_packages, setup
+
+HERE = os.path.abspath(os.path.dirname(__file__))
+
+
+def get_version(module='spyder_vcs'):
+    """Get version."""
+    with open(os.path.join(HERE, module, '__init__.py'), 'r') as f:
+        data = f.read()
+    lines = data.split('\n')
+    for line in lines:
+        if line.startswith('VERSION_INFO'):
+            version_tuple = ast.literal_eval(line.split('=')[-1].strip())
+            version = '.'.join(map(str, version_tuple))
+            break
+    return version
+
+
+def get_description():
+    """Get long description."""
+    with open(os.path.join(HERE, 'README.md'), 'r') as f:
+        data = f.read()
+    return data
+
+
+REQUIREMENTS = [
+    # 'spyder>5.3.0',
+]
+
+EXTRAS_REQUIRE = {
+}
+
+
+setup(
+    name='spyder-vcs',
+    version=get_version(),
+    keywords=['Spyder', 'Plugin'],
+    url='https://github.com/spyder-ide/spyder-vcs',
+    license='MIT',
+    author='Spyder Project Contributors',
+    author_email='spyder.python@gmail.com',
+    description='Spyder Plugin for VCSs',
+    long_description=get_description(),
+    long_description_content_type='text/x-md',
+    packages=find_packages(exclude=['contrib', 'docs']),
+    install_requires=REQUIREMENTS,
+    include_package_data=True,
+    classifiers=[
+        'Development Status :: 4 - Beta',
+        'Intended Audience :: Developers',
+        'Intended Audience :: Science/Research',
+        'License :: OSI Approved :: MIT License',
+        'Operating System :: MacOS',
+        'Operating System :: Microsoft :: Windows',
+        'Operating System :: POSIX :: Linux',
+        'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8'
+        ],
+    extras_require=EXTRAS_REQUIRE,
+    entry_points={
+        "spyder.plugins": [
+            "vcs = spyder_vcs.plugin:VCS"
+        ],
+    })

--- a/spyder_vcs/__init__.py
+++ b/spyder_vcs/__init__.py
@@ -1,16 +1,12 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# Copyright (c) 2009- Spyder Project Contributors
+# Copyright (c) 2022- Spyder Project Contributors
 #
 # Distributed under the terms of the MIT License
 # (see spyder/__init__.py for details)
 # -----------------------------------------------------------------------------
 """Spyder VCS Plugin."""
 
-try:
-    from .plugin import VCS as PLUGIN_CLASS
-except ImportError:
-    pass
-else:
-    PLUGIN_CLASSES = [PLUGIN_CLASS]
+VERSION_INFO = (1, 0, 0, 'dev0')
+__version__ = '.'.join(map(str, VERSION_INFO))

--- a/spyder_vcs/plugin.py
+++ b/spyder_vcs/plugin.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# Copyright (c) 2009- Spyder Project Contributors
+# Copyright (c) 2022- Spyder Project Contributors
 #
 # Distributed under the terms of the MIT License
 # (see spyder/__init__.py for details)
@@ -19,7 +19,7 @@ from qtpy.QtCore import Slot, Signal
 # Local imports
 from spyder.api.translations import get_translation
 from spyder.api.plugins import Plugins, SpyderDockablePlugin
-from spyder.config.manager import CONF
+# from spyder.config.manager import CONF
 from spyder.utils import icon_manager as ima
 
 from .backend.api import VCSBackendManager
@@ -36,7 +36,7 @@ class VCS(SpyderDockablePlugin):  # pylint: disable=W0201
     VCS plugin.
     """
 
-    NAME = "VCS"
+    NAME = "vcs"
     REQUIRES = [Plugins.Projects]
     OPTIONAL = [Plugins.Shortcuts, Plugins.MainMenu]
     TABIFY = [Plugins.Help]
@@ -94,12 +94,11 @@ class VCS(SpyderDockablePlugin):  # pylint: disable=W0201
 
     def __init__(self, *args, **kwargs):
         self.vcs_manager = VCSBackendManager(None)
-        # workaround when imported as 3rd party plugin
-        kwargs.setdefault("configuration", CONF)
         super().__init__(*args, **kwargs)
 
     # Reimplemented APIs
-    def get_name(self):
+    @staticmethod
+    def get_name():
         return _("VCS")
 
     def get_description(self):
@@ -109,7 +108,7 @@ class VCS(SpyderDockablePlugin):  # pylint: disable=W0201
         # return self.create_icon("code_fork")
         return qta.icon("mdi.source-branch")
 
-    def register(self):
+    def on_initialize(self):
         # Register backends
         self.vcs_manager.register_backend(GitBackend)
 
@@ -211,13 +210,14 @@ class VCS(SpyderDockablePlugin):  # pylint: disable=W0201
                 shortcuts.register_shortcut(
                     action, self.NAME, action_name, plugin_name=self.NAME
                 )
-        if mainmenu:
-            appmenu = mainmenu.create_application_menu(
-                self.NAME + "_menu",
-                _("&VCS"),
-            )
-            for action in self.get_actions().values():
-                mainmenu.add_item_to_application_menu(action, menu=appmenu)
+        # TODO: Fix the main menu API usage.
+        # if mainmenu:
+        #     appmenu = mainmenu.create_application_menu(
+        #         self.NAME + "_menu",
+        #         _("&VCS"),
+        #     )
+        #     for action in self.get_actions().values():
+        #         mainmenu.add_item_to_application_menu(action)
 
     # Public API
     def get_repository(self) -> Optional[str]:
@@ -304,11 +304,6 @@ class VCS(SpyderDockablePlugin):  # pylint: disable=W0201
         branch_list.select(branchname)
 
         self.get_widget().select_branch(branchname)
-
-    # workarounds when imported as 3rd party plugin
-    register_plugin = register
-
-    DESCRIPTION = get_description(None)
 
     @property
     def dockwidget(self):

--- a/spyder_vcs/widgets/vcsgui.py
+++ b/spyder_vcs/widgets/vcsgui.py
@@ -23,12 +23,12 @@ from qtpy.QtWidgets import (
     QHBoxLayout,
     QMessageBox,
     QSizePolicy,
-    QVBoxLayout
+    QVBoxLayout,
 )
 
 # Local imports
 from spyder.api.plugins import Plugins
-from spyder.api.widgets import PluginMainWidget
+from spyder.api.widgets.main_widget import PluginMainWidget
 from spyder.api.translations import get_translation
 
 from .auth import CreateDialog, CommitComponent, RemoteComponent
@@ -39,7 +39,7 @@ from .changes import ChangesComponent
 from .history import CommitHistoryComponent
 from ..backend.errors import VCSBackendFail
 
-_ = get_translation('spyder')
+_ = get_translation("spyder")
 
 
 class VCSWidget(PluginMainWidget):
@@ -82,9 +82,8 @@ class VCSWidget(PluginMainWidget):
         toolbar = QHBoxLayout()
         self.branch_list = BranchesComponent(manager, parent=self)
         self.branch_list.setSizePolicy(
-            QSizePolicy(QSizePolicy.Expanding, QSizePolicy.Preferred))
-
-        refresh_button = action2button(plugin.refresh_action, parent=self)
+            QSizePolicy(QSizePolicy.Expanding, QSizePolicy.Preferred)
+        )
 
         self.changes = ChangesComponent(
             manager,
@@ -133,11 +132,13 @@ class VCSWidget(PluginMainWidget):
         rootlayout.addWidget(self.changes)
         rootlayout.addWidget(self.unstaged_changes)
         rootlayout.addWidget(self.staged_changes)
-        self.components.extend((
-            self.changes,
-            self.unstaged_changes,
-            self.staged_changes,
-        ))
+        self.components.extend(
+            (
+                self.changes,
+                self.unstaged_changes,
+                self.staged_changes,
+            )
+        )
 
         rootlayout.addWidget(self.commit)
         self.components.append(self.commit)
@@ -162,15 +163,15 @@ class VCSWidget(PluginMainWidget):
         self.branch_list.sig_branch_changed.connect(self.refresh_all)
         self.branch_list.sig_branch_changed.connect(plugin.sig_branch_changed)
 
-        self.unstaged_changes.changes_tree.sig_stage_toggled.connect(
-            self._post_stage)
-        self.unstaged_changes.changes_tree.sig_stage_toggled[
-            bool, str].connect(self._post_stage)
+        self.unstaged_changes.changes_tree.sig_stage_toggled.connect(self._post_stage)
+        self.unstaged_changes.changes_tree.sig_stage_toggled[bool, str].connect(
+            self._post_stage
+        )
 
-        self.staged_changes.changes_tree.sig_stage_toggled.connect(
-            self._post_stage)
+        self.staged_changes.changes_tree.sig_stage_toggled.connect(self._post_stage)
         self.staged_changes.changes_tree.sig_stage_toggled[bool, str].connect(
-            self._post_stage)
+            self._post_stage
+        )
 
         self.commit.sig_auth_operation_success.connect(self.history.refresh)
         self.commit.sig_auth_operation_success.connect(self.remote.refresh)
@@ -179,7 +180,8 @@ class VCSWidget(PluginMainWidget):
         self.history.sig_last_commit.connect(self.remote.refresh)
 
         self.repo_not_found.create_dialog.sig_repository_ready.connect(
-            plugin.set_repository)
+            plugin.set_repository
+        )
 
         plugin.sig_repository_changed.connect(self.setup_repo)
         plugin.refresh_action.triggered.connect(self.refresh_all)
@@ -187,11 +189,15 @@ class VCSWidget(PluginMainWidget):
         # Toolbar
         toolbar = self.get_main_toolbar()
         toolbar.addWidget(self.branch_list)
-        self.add_item_to_toolbar(
-            refresh_button,
-            toolbar=toolbar,
-            section="main_section",
-        )
+        refresh_button = action2button(plugin.refresh_action, parent=toolbar)
+        toolbar.addWidget(refresh_button)
+
+        # TODO: Fix the toolbar API usage.
+        # self.add_item_to_toolbar(
+        #     refresh_button,
+        #     toolbar=toolbar,
+        #     section="main_section",
+        # )
 
         # Extra setup
         self.repo_not_found.hide()
@@ -211,7 +217,8 @@ class VCSWidget(PluginMainWidget):
         if plugin.get_repository() is None:
             if getattr(plugin, "create_vcs_action", None) is not None:
                 project_path = plugin.get_plugin(
-                    Plugins.Projects).get_active_project_path()
+                    Plugins.Projects
+                ).get_active_project_path()
 
                 # Show No repository available only if there is an active project
                 if project_path:
@@ -266,9 +273,10 @@ class VCSWidget(PluginMainWidget):
                     # Prevent show the error if the backend is buggy and
                     # the repository is not really broken
                     QMessageBox.critical(
-                        self, _("Broken repository"),
-                        _("The repository is broken and cannot be used anymore."
-                          ))
+                        self,
+                        _("Broken repository"),
+                        _("The repository is broken and cannot be used anymore."),
+                    )
                     return
 
         # TODO: use issue reporter
@@ -301,13 +309,17 @@ class VCSWidget(PluginMainWidget):
     def _post_undo(self, commit: dict) -> None:
         """Update commit message."""
         if not self.commit.commit_message.toPlainText():
-            text = (commit.get("content") or commit.get("description")
-                    or commit.get("title", ""))
+            text = (
+                commit.get("content")
+                or commit.get("description")
+                or commit.get("title", "")
+            )
             self.commit.commit_message.setPlainText(text)
 
 
 class RepoNotFoundComponent(BaseComponent, QWidget):
     """A widget to show when no repository is found."""
+
     def __init__(self, *args, create_vcs_action: QAction, **kwargs):
         super().__init__(*args, **kwargs)
 
@@ -324,7 +336,8 @@ class RepoNotFoundComponent(BaseComponent, QWidget):
         self.no_repo_found_label.setAlignment(Qt.AlignHCenter | Qt.AlignTop)
         self.create_button.setStyleSheet("background-color: #1122cc;")
         self.create_button.setSizePolicy(
-            QSizePolicy(QSizePolicy.Preferred, QSizePolicy.Preferred))
+            QSizePolicy(QSizePolicy.Preferred, QSizePolicy.Preferred)
+        )
 
         layout = QVBoxLayout(self)
         layout.setAlignment(Qt.AlignHCenter | Qt.AlignVCenter)
@@ -335,11 +348,13 @@ class RepoNotFoundComponent(BaseComponent, QWidget):
         # Slots
         self.create_button.triggered.connect(self.show_create_dialog)
         self.create_dialog.rejected.connect(
-            partial(self.create_button.setEnabled, True))
+            partial(self.create_button.setEnabled, True)
+        )
 
     def setup(self, project_path: str):
         self.no_repo_found_label.setText(
-            _("<h3>No repository available</h3>\nin ") + str(project_path))
+            _("<h3>No repository available</h3>\nin ") + str(project_path)
+        )
 
         self.create_dialog.setup(project_path)
         self.create_button.setEnabled(bool(self.manager.create_vcs_types))


### PR DESCRIPTION
Add `setup.py` and `setup.cfg` with the required plugin entrypoint. Those files are inspired from the spyder-terminal ones.
Also adapt the code (or comment it with a TODO) to the changes done in the Spyder API.

Next step: Complete the migration for the current API.

Note: I'll self-merge this later, leave this opened mainly for visibility.

