### PR TITLE
Fix Spyder API usages

### DIFF
--- a/spyder_vcs/plugin.py
+++ b/spyder_vcs/plugin.py
@@ -210,14 +210,15 @@ class VCS(SpyderDockablePlugin):  # pylint: disable=W0201
                 shortcuts.register_shortcut(
                     action, self.NAME, action_name, plugin_name=self.NAME
                 )
-        # TODO: Fix the main menu API usage.
-        # if mainmenu:
-        #     appmenu = mainmenu.create_application_menu(
-        #         self.NAME + "_menu",
-        #         _("&VCS"),
-        #     )
-        #     for action in self.get_actions().values():
-        #         mainmenu.add_item_to_application_menu(action)
+
+        if mainmenu:
+            menu_id = self.NAME + "_menu"
+            mainmenu.create_application_menu(
+                menu_id,
+                _("&VCS"),
+            )
+            for action in self.get_actions().values():
+                mainmenu.add_item_to_application_menu(action, menu_id=menu_id)
 
     # Public API
     def get_repository(self) -> Optional[str]:

--- a/spyder_vcs/widgets/vcsgui.py
+++ b/spyder_vcs/widgets/vcsgui.py
@@ -42,6 +42,11 @@ from ..backend.errors import VCSBackendFail
 _ = get_translation("spyder")
 
 
+class VCSToolbar:
+    main_section = "main_section"
+    branch_combo = "branch_combo"
+
+
 class VCSWidget(PluginMainWidget):
     """VCS main widget."""
 
@@ -84,6 +89,7 @@ class VCSWidget(PluginMainWidget):
         self.branch_list.setSizePolicy(
             QSizePolicy(QSizePolicy.Expanding, QSizePolicy.Preferred)
         )
+        self.branch_list.ID = VCSToolbar.branch_combo
 
         self.changes = ChangesComponent(
             manager,
@@ -188,16 +194,17 @@ class VCSWidget(PluginMainWidget):
 
         # Toolbar
         toolbar = self.get_main_toolbar()
+        # HACK: Add the widget directly instead of pass it to add_item_to_toolbar
+        #       because using that doesn't work.
         toolbar.addWidget(self.branch_list)
-        refresh_button = action2button(plugin.refresh_action, parent=toolbar)
-        toolbar.addWidget(refresh_button)
 
-        # TODO: Fix the toolbar API usage.
-        # self.add_item_to_toolbar(
-        #     refresh_button,
-        #     toolbar=toolbar,
-        #     section="main_section",
-        # )
+        # BUG: This causes the 3 dots to appear to the refresh action.
+        for item in [plugin.refresh_action]:
+            self.add_item_to_toolbar(
+                item,
+                toolbar=toolbar,
+                section=VCSToolbar.main_section,
+            )
 
         # Extra setup
         self.repo_not_found.hide()


### PR DESCRIPTION
This makes the VCS main menu entry appear again and partially fix toolbar usage.
For some reasons, the branches combobox is not visible when using `SpyderToolbar.add_item`, but it's visible when calling `QToolBar.addWidget` directly. I debug it and `MainWidgetToolbar._render` seems to call `addWidget` correctly for the combobox. I didn't investigate further. 

Next step: Setup the CI and port the tests here.

Note: I'll self-merge after 15-20 hours, leave this opened mainly for visibility.